### PR TITLE
Results widget checkboxes aren't saving

### DIFF
--- a/includes/abstracts/abstract-wpcm-widget.php
+++ b/includes/abstracts/abstract-wpcm-widget.php
@@ -131,7 +131,7 @@ abstract class WPCM_Widget extends WP_Widget {
 					$instance[ $key ] = wp_kses( trim( wp_unslash( $new_instance[ $key ] ) ), wp_kses_allowed_html( 'post' ) );
 				break;
 				case 'checkbox' :
-					$instance[ $key ] = is_null( $new_instance[ $key ] ) ? 0 : 1;
+					$instance[ $key ] = sanitize_text_field( $new_instance[ $key ] );
 				break;
 				case 'player_stats' :
 					if ( is_array( $new_instance[ $key ] ) ) $new_instance[ $key ] = implode(',', $new_instance[ $key ]);
@@ -261,7 +261,7 @@ abstract class WPCM_Widget extends WP_Widget {
 				case "checkbox" :
 					?>
 					 <p class="wpcm-widget-admin">
-						<input id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( $key ) ); ?>" type="checkbox" value="1" <?php checked( $value, 1 ); ?> />
+						<input id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( $key ) ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
 						<label for="<?php echo $this->get_field_id( $key ); ?>"><?php echo $setting['label']; ?></label>
 					</p>
 					<?php

--- a/includes/widgets/class-wpcm-widget-results.php
+++ b/includes/widgets/class-wpcm-widget-results.php
@@ -79,32 +79,32 @@ class WPCM_Results_Widget extends WPCM_Widget
             ),
             'show_abbr' => array(
                 'type'  => 'checkbox',
-                'std'   => 0,
+                'std'   => '',
                 'label' => __('Abbreviations', 'wp-club-manager')
             ),
             'show_date' => array(
                 'type'  => 'checkbox',
-                'std'   => 1,
+                'std'   => '1',
                 'label' => __('Date', 'wp-club-manager')
             ),
             'show_time' => array(
                 'type'  => 'checkbox',
-                'std'   => 1,
+                'std'   => '1',
                 'label' => __('Kick Off', 'wp-club-manager')
             ),
             'show_score' => array(
                 'type'  => 'checkbox',
-                'std'   => 1,
+                'std'   => '1',
                 'label' => __('Score', 'wp-club-manager')
             ),
             'show_comp' => array(
                 'type'  => 'checkbox',
-                'std'   => 1,
+                'std'   => '1',
                 'label' => __('Competition', 'wp-club-manager')
             ),
             'show_team' => array(
                 'type'  => 'checkbox',
-                'std'   => 0,
+                'std'   => '',
                 'label' => __('Team', 'wp-club-manager')
             ),
             'link_options' => array(


### PR DESCRIPTION
Resolves [# https://github.com/WPClubManager/victory/issues/1](https://github.com/WPClubManager/victory/issues/1)

## Description
For some reason 0/1 (number) value caused an issue. Converting the value to '1' for checked and '' (empty) for unchecked solves the issue. 
## Testing Instructions

1.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPClubManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPClubManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
