### PR TITLE
Update wpcm-match-functions.php

### DIFF
--- a/includes/wpcm-match-functions.php
+++ b/includes/wpcm-match-functions.php
@@ -319,7 +319,7 @@ function wpcm_get_match_team( $post ) {
 			$t_id = $team->term_id;
 			$team_meta = get_option( "taxonomy_term_$t_id" );
 			if ( is_array( $team_meta ) && ! empty( $team_meta['wpcm_team_label'] ) ) {
-				$label = $competition_meta['wpcm_team_label'];
+				$label = $team_meta['wpcm_team_label'];
 			} else {
 				$label = $name;
 			}


### PR DESCRIPTION
The code is trying to access an undefined variable $competition_meta. It should be using $team_meta instead of $competition_meta.

Resolves #

Warning: Undefined variable $competition_meta in wp-club-manager/includes/wpcm-match-functions.php on line 322

Warning: Trying to access array offset on value of type null in wp-club-manager/includes/wpcm-match-functions.php on line 322