### PR TITLE
Fixed: Unable to update player scores in a match using mobile devices.

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1477,3 +1477,59 @@ li.ui-timepicker-selected .ui-timepicker-duration,
 #wpcm_mapbox_type-row {
 	display: none;
 }
+
+@media screen and (max-width: 600px) {
+	table.wpcm-match-players-table {
+		border: 0;
+	}
+
+	table.wpcm-match-players-table caption {
+		font-size: 1.3em;
+	}
+
+	table.wpcm-match-players-table thead {
+		display: none; /* Hide the table header in mobile view */
+	}
+
+	table.wpcm-match-players-table tr {
+		border-bottom: 3px solid #ddd;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		margin-bottom: .625em;
+	}
+
+	table.wpcm-match-players-table tbody tr td.names {
+		text-align: left;
+	}
+
+	table.wpcm-match-players-table tbody tr td input {
+		max-width: 100px !important;
+	}
+
+	table.wpcm-match-players-table td {
+		border-bottom: 1px solid #ddd;
+		flex: 1 1 calc(50% - 5px); /* Set width for each column with a 5px gap */
+		text-align: right;
+		margin-right: 5px; /* Adjust the gap value as needed */
+	}
+
+	table.wpcm-match-players-table td::before {
+		content: attr(data-label);
+		float: left; /* Reset float for mobile view */
+		text-transform: uppercase;
+		padding-top: 10px;
+		padding-left: 35px;
+	}
+
+	table.wpcm-match-players-table td:last-child {
+		border-bottom: 0;
+		margin-right: 0; /* Remove the gap for the last column */
+	}
+
+	table.wpcm-match-players-table tbody tr td.mvp, table.wpcm-match-players-table tbody tr td.captain, table.wpcm-match-players-table tbody tr td.yellowcards, table.wpcm-match-players-table tbody tr td.redcards {
+		padding-left: 0;
+		padding-right: 0;
+		text-align: right;
+	}
+}

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -326,6 +326,9 @@ jQuery( function($){
 
 	$(document).ready(function(){
 		$(".combify-input").combify();
+		$(".wpcm-match-players-table td input").on("click", function() {
+			$(this).focus();
+		});
 	});
 
 });

--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-players.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-players.php
@@ -399,7 +399,7 @@ class WPCM_Meta_Box_Match_Players {
 							<?php echo apply_filters( 'wpcm_players_shirt_number_output', $shirt, $player->ID, $selected_players, $type, $count, $played ); ?>
 
 
-								<td class="names">
+								<td scope="row" class="names">
 									<i class="dashicons dashicons-move"></i>
 									<label class="selectit">
 										<input type="checkbox" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][checked]" class="player-select" value="1" <?php checked( true, $played ); ?> />
@@ -429,43 +429,42 @@ class WPCM_Meta_Box_Match_Players {
 
 										if ( $key == 'greencards' ) { ?>
 
-											<td class="<?php echo $key; ?>">
+											<td data-label="GC" class="<?php echo $key; ?>">
 												<input type="checkbox" data-card="green" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="1" <?php checked( true, $keyarray ); ?><?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
 										<?php } elseif ( $key == 'yellowcards' ) { ?>
 
-											<td class="<?php echo $key; ?>">
+											<td data-label="YC" class="<?php echo $key; ?>">
 												<input type="checkbox" data-card="yellow" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="1" <?php checked( true, $keyarray ); ?><?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
 										<?php } elseif ( $key == 'blackcards' ) { ?>
 
-											<td class="<?php echo $key; ?>">
+											<td data-label="BC" class="<?php echo $key; ?>">
 												<input type="checkbox" data-card="black" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="1" <?php checked( true, $keyarray ); ?><?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
 										<?php } elseif ( $key == 'redcards' ) { ?>
 
-											<td class="<?php echo $key; ?>">
+											<td data-label="RC" class="<?php echo $key; ?>">
 												<input type="checkbox" data-card="red" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="1" <?php checked( true, $keyarray ); ?><?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
 										<?php } elseif ( $key == 'rating' ) { ?>
 
-											<td class="<?php echo $key; ?>">
+											<td data-label="RAT" class="<?php echo $key; ?>">
 												<input type="number" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="<?php echo ( $type == 'subs_not_used' ? '0' : wpcm_stats_value( $selected_players[$type], $player->ID, $key ) ); ?>" min="0" max="10"<?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
 										<?php } elseif ( $key == 'mvp' ) { ?>
 
-											<td class="mvp">
+											<td data-label="POM" class="mvp">
 												<input type="radio" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="1" <?php checked( true, $keyarray ); ?><?php if ( !$played ) echo ' disabled'; ?> />
 											</td>
 
 										<?php } else { ?>
-
-											<td class="<?php echo $key; ?>">
+											<td data-label="<?php echo $wpcm_player_stats_labels[ $key ]; ?>" class="<?php echo $key; ?>">
 												<input type="number" data-player="<?php echo $player->ID; ?>" name="wpcm_players[<?php echo $type; ?>][<?php echo $player->ID; ?>][<?php echo $key; ?>]" value="<?php echo ( $type == 'subs_not_used' ? '0' : wpcm_stats_value( $selected_players[$type], $player->ID, $key ) ); ?>"<?php if ( !$played ) echo ' disabled'; ?>/>
 											</td>
 
@@ -477,7 +476,7 @@ class WPCM_Meta_Box_Match_Players {
 
 								if ( $type == 'lineup' ) { ?>
 
-									<td class="captain">
+									<td data-label="CAP" class="captain">
 
 										<input type="radio" data-player="<?php echo $player->ID; ?>" name="wpcm_match_captain" value="<?php echo $player->ID; ?>"<?php checked($captain, $player->ID); ?><?php if ( !$played ) echo ' disabled'; ?> />
 									</td>


### PR DESCRIPTION
Resolves #55 

## Description
The issue stems from two things:

- There is a very small clickable area of the input field in mobile
- Sortable plugin prevents the input field to be selected when clicked.

## Testing Instructions

1. Using mobile device, navigate to matches.
2. Select the match.
3. Scroll down where the player section is located.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPClubManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPClubManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
