### PR TITLE
Fixed mobile device issue preventing player score updates in matches

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -396,9 +396,8 @@ table.wpcm-match-players-table tbody tr td.names {
 	padding-right: 24px;
 }
 
-table.wpcm-match-players-table tbody tr td input,
 table.wpcm-match-players-table tbody tr td input {
-	max-width:50px;
+	max-width:60px;
 }
 
 table.wpcm-match-players-table tbody tr td.mvp,

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -214,6 +214,7 @@ jQuery( function($){
 	var itemList = jQuery('.wpcm-sortable');
 
     itemList.sortable({
+		handle: ".names .name, .names .dashicons-move",
     	cursor: 'move',
         update: function(event, ui) {
             jQuery('#loading-animation').show(); // Show the animate loading gif while waiting


### PR DESCRIPTION
Resolves #55 

## Description

- The issue was that the sortable handle was attached to the table row. This prevented the click/select event of the input elements. The sortable handle is attached now to the player name and the move icon.

## Testing Instructions

1. Using mobile device, navigate to matches.
2. Select the match.
3. Scroll down where the player section is located.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPClubManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPClubManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
